### PR TITLE
Add travis ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ deploy:
   provider: pages
   skip_cleanup: true
   github_token: $GITHUB_TOKEN  # Set in the settings page of your repository, as a secure variable
-  keep_history: false
+  keep_history: true
   target_branch: gh-pages
   local_dir: docs
   on:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ install:
 script:
     - git submodule update --init --recursive
     - hugo
+    - touch docs/.nojekyll
 
 deploy:
   provider: pages

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,19 @@
+---
+install:
+    - wget -O /tmp/hugo.deb https://github.com/gohugoio/hugo/releases/download/v0.56.3/hugo_extended_0.56.3_Linux-64bit.deb
+    - sudo dpkg -i /tmp/hugo.deb
+    - npm install
+
+script:
+    - git submodule update --init --recursive
+    - hugo
+
+deploy:
+  provider: pages
+  skip_cleanup: true
+  github_token: $GITHUB_TOKEN  # Set in the settings page of your repository, as a secure variable
+  keep_history: false
+  target_branch: gh-pages
+  local_dir: docs
+  on:
+    branch: master


### PR DESCRIPTION
masterブランチが更新されたら、自動でビルドして gh-pages ブランチにビルド結果(docsフォルダ) をpushする TravisCI の設定を作成

#7

mergeした時点では何も起こらない。
merge されたら travsis 側に設定を作成し、githubにアクセスできるようにします。

gh-pages ブランチの方でサイトの動作確認ができたら、docs フォルダを削除します。
以降、master にpushすると、Travis経由でgh-pagesが更新されてサイトが更新されます。
