### PR TITLE
Change VRoid url to vroid.com

### DIFF
--- a/content/en/docs/vrm/vrm_applications.md
+++ b/content/en/docs/vrm/vrm_applications.md
@@ -15,7 +15,7 @@ weight: 4
 ##  Character maker
 
 * [Vkatsu](http://vkatsu.jp/)
-* [VRoid](https://vroid.pixiv.net/)
+* [VRoid](https://vroid.com/en)
 * [SeshiruHenshin](https://fantia.jp/fanclubs/10552)
 
 ##  Live streaming tool

--- a/content/ja/docs/vrm/vrm_applications.md
+++ b/content/ja/docs/vrm/vrm_applications.md
@@ -15,7 +15,7 @@ weight: 4
 ##  キャラメイクツール
 
 * [Vカツ](http://vkatsu.jp/)
-* [VRoid](https://vroid.pixiv.net/)
+* [VRoid](https://vroid.com/)
 * [セシル変身アプリ](https://fantia.jp/fanclubs/10552)
 
 ##  配信ツール


### PR DESCRIPTION
表題の通り、`VRoid` のURLを変更します。 `VRoid Hub`のURLが記載されている箇所もありますが、そちらは変更無しで大丈夫です。