### PR TITLE
[WIP] Remove Vカツ (Vkatsu) from vrm_applications page

### DIFF
--- a/content/en/docs/vrm/vrm_applications.md
+++ b/content/en/docs/vrm/vrm_applications.md
@@ -19,7 +19,6 @@ weight: 4
 	
 ##  Character maker
 
-* [Vkatsu](http://vkatsu.jp/)
 * [VRoid](https://vroid.com/en)
 * [SeshiruHenshin](https://fantia.jp/fanclubs/10552)
 

--- a/content/ja/docs/vrm/vrm_applications.md
+++ b/content/ja/docs/vrm/vrm_applications.md
@@ -20,7 +20,6 @@ weight: 4
 
 ##  キャラメイクツール
 
-* [Vカツ](http://vkatsu.jp/)
 * [VRoid](https://vroid.com/)
 * [セシル変身アプリ](https://fantia.jp/fanclubs/10552)
 


### PR DESCRIPTION
Vカツ does not really support VRM.

---

「VRMファイルが使えるアプリケーションは？」ページの「キャラメイクツール」の項へ挙げられていますが、少なくとも現時点では、VRMファイルのエクスポート等、VRMファイルを取り扱う機能はありません。

Vカツの付加サービスとして、ニコニ立体へVRM扱いで投稿するものはありますが、そちらのサービスを指して、こちらのページへリストアップするのは語弊があり、また、誤解を招く原因にもなっています。

あるいは、「VRMを内部的に利用しているサービス・システム」のような項目を作成し、そちらへ同様のサービスと共に列挙していくのが良いかもしれません。