### PR TITLE
Display the platform in all applications

### DIFF
--- a/content/en/docs/vrm/vrm_applications.md
+++ b/content/en/docs/vrm/vrm_applications.md
@@ -14,72 +14,86 @@ weight: 4
 
 ##  Plug-in
 
-* [VRM_IMPORTER](https://github.com/saturday06/VRM_IMPORTER_for_Blender2_8) (Blender Add-on)
-* [VRM4U](https://github.com/ruyo/VRM4U)
-* [glTF-Maya-Exporter](https://github.com/kashikacojp/glTF-Maya-Exporter)
-* [VRM Converter for VRChat](https://www.v-market.work/ec/items/122/detail/) (Unity editor extension)
-	
+| Application | Platform |
+|-------------|----------|
+| [VRM_IMPORTER](https://github.com/saturday06/VRM_IMPORTER_for_Blender2_8) | Blender add-on |
+| [VRM4U](https://github.com/ruyo/VRM4U) | UnrealEngine plug-in |
+| [glTF-Maya-Exporter](https://github.com/kashikacojp/glTF-Maya-Exporter) | Maya script |
+| [VRM Converter for VRChat](https://www.v-market.work/ec/items/122/detail/) | Unity editor extension |
+
 ##  Character maker
 
-* [Vkatsu](http://vkatsu.jp/)
-* [VRoid](https://vroid.com/en)
-* [SeshiruHenshin](https://fantia.jp/fanclubs/10552)
+| Application | Platform |
+|-------------|----------|
+| [Vkatsu](http://vkatsu.jp/) | Windows, iOS, Android |
+| [VRoid](https://vroid.com/en) | Windows, macOS |
+| [SeshiruHenshin](https://fantia.jp/fanclubs/10552) | Windows, macOS |
 
 ##  Live streaming tool
 
-* [Virtual Cast](https://virtualcast.jp/)
-* [Custom Cast](https://customcast.jp/)
-* [VDRAW](https://sites.google.com/view/vdraw/)
-* [REALITY](https://le.wrightflyer.net/reality/)
-* [SHOWROOM V](https://campaign.showroom-live.com/showroom-v/)
-* [Hitogata](https://sites.google.com/site/vhitogata/)
-* [3tene](https://3tene.com/)
-* [Puppemoji](https://www.puppemoji.com/)
-* [Wakaru](https://store.steampowered.com/app/870820/Wakaru_ver_beta/)
-* [VirtualMotionCapture](https://github.com/sh-akira/VirtualMotionCapture)
-* [FaceVTuber](https://facevtuber.com/)
-* [Mayalive](https://materializer.co/lab/mayalive)
-* [WeVTuber](https://wevtubers.appspot.com/)
-* [LiveAvatar](https://github.com/m2wasabi/LiveAvatar)
-* [Clarie](https://biscrat.booth.pm/items/1193414)
-* [Luppet](https://luppet.appspot.com/)
-* [vear](https://apps.apple.com/jp/app/vear/id1490697369)
-* [CharWebCam](https://github.com/xelloss120/CharWebCam)
-* [VMagicMirror](https://malaybaku.github.io/VMagicMirror/en/)
+| Application | Platform |
+|-------------|----------|
+| [Virtual Cast](https://virtualcast.jp/) | Windows VR |
+| [Custom Cast](https://customcast.jp/) | iOS, Android |
+| [VDRAW](https://sites.google.com/view/vdraw/) | Windows |
+| [REALITY](https://le.wrightflyer.net/reality/) | iOS, Android |
+| [SHOWROOM V](https://campaign.showroom-live.com/showroom-v/) | iOS |
+| [Hitogata](https://sites.google.com/site/vhitogata/) | Windows |
+| [3tene](https://3tene.com/) | Windows, macOS |
+| [Puppemoji](https://www.puppemoji.com/) | iOS |
+| [Wakaru](https://store.steampowered.com/app/870820/Wakaru_ver_beta/) | Windows |
+| [VirtualMotionCapture](https://github.com/sh-akira/VirtualMotionCapture) | Windows VR |
+| [FaceVTuber](https://facevtuber.com/) | Google Chrome |
+| [Mayalive](https://materializer.co/lab/mayalive) | Windows, macOS |
+| [WeVTuber](https://wevtubers.appspot.com/) | Windows Google Chrome, Safari |
+| [LiveAvatar](https://github.com/m2wasabi/LiveAvatar) | HTC VIVE |
+| [Clarie](https://biscrat.booth.pm/items/1193414) | Windows VR |
+| [Luppet](https://luppet.appspot.com/) | Windows + Leap Motion |
+| [vear](https://apps.apple.com/jp/app/vear/id1490697369) | iOS |
+| [CharWebCam](https://github.com/xelloss120/CharWebCam) | Windows |
+| [VMagicMirror](https://malaybaku.github.io/VMagicMirror/en/) | Windows 
 
 ##  Metaverse
 
-* [cluster](https://cluster.mu/)
-* [VWorld](https://naby.booth.pm/items/990663)
+| Application | Platform |
+|-------------|----------|
+| [cluster](https://cluster.mu/) | PCVR, Windows, macOS, iOS, Android |
+| [VWorld](https://naby.booth.pm/items/990663) | Windows |
 
 ##  Game
 
-* [SEIYA](https://wandv.jp/seiya/)
-* [BONFIRE](https://orenodinner.booth.pm/items/952450)
-* [TSUN-TSUN VR](https://store.steampowered.com/app/867090/VR__TSUNTSUN_VR/)
-* [KOROKORO System](https://www.mediaplex.co.jp/korokoro/)
-* [PilotXross](https://n-mattun.booth.pm/)
+| Application | Platform |
+|-------------|----------|
+| [SEIYA](https://wandv.jp/seiya/) | Windows VR |
+| [BONFIRE](https://orenodinner.booth.pm/items/952450) | Oculus Go |
+| [TSUN-TSUN VR](https://store.steampowered.com/app/867090/VR__TSUNTSUN_VR/) | Windows VR |
+| [KOROKORO System](https://www.mediaplex.co.jp/korokoro/) | Oculus Rift |
+| [PilotXross](https://n-mattun.booth.pm/) | Windows VR |
 
 ##  Viewer
 
-* [Babylon VRM Viewer](https://github.com/virtual-cast/babylon-vrm-loader/)
-* [Three-VRM](https://github.com/pixiv/three-vrm/)
-* [VPocket (Android / iOS)](https://play.google.com/store/apps/details?id=com.BooApps.VPocket)
-* [VRMViewer](https://www43.atwiki.jp/beamman/)
-* [VRM Viewer](https://vrm-viewer.yukimochi.io/)
-* [VRMQuickLook](https://github.com/magicien/VRMQuickLook)
-* [VRM Live Viewer](http://fantom1x.blog130.fc2.com/blog-entry-309.html)
-* [UniWinApi Example project](https://github.com/kirurobo/UniWinApi)
-* [VRM OningyoAsobi](https://120byte.booth.pm/items/1099618)
-* [KinectV2VRM](https://github.com/m2wasabi/KinectV2VRM)
-* [MocuMocuVRM](http://www.vrai.jp/vr_mocuvrm_en.html)
-* [VRM Display](https://akarimichi.github.io/vrm-display-releases/)
+| Application | Platform |
+|-------------|----------|
+| [Babylon VRM Viewer](https://github.com/virtual-cast/babylon-vrm-loader/) | Babylon.js extension |
+| [Three-VRM](https://github.com/pixiv/three-vrm/) | three.js extension |
+| [VPocket (Android / iOS)](https://play.google.com/store/apps/details?id=com.BooApps.VPocket) | Android, iOS |
+| [VRMViewer](https://www43.atwiki.jp/beamman/) | Windows |
+| [VRM Viewer](https://vrm-viewer.yukimochi.io/) | Web browser |
+| [VRMQuickLook](https://github.com/magicien/VRMQuickLook) | macOS |
+| [VRM Live Viewer](http://fantom1x.blog130.fc2.com/blog-entry-309.html) | Windows |
+| [UniWinApi Example project](https://github.com/kirurobo/UniWinApi) | Unity library |
+| [VRM OningyoAsobi](https://120byte.booth.pm/items/1099618) | Windows VR |
+| [KinectV2VRM](https://github.com/m2wasabi/KinectV2VRM) | Unity library |
+| [MocuMocuVRM](http://www.vrai.jp/vr_mocuvrm_en.html) | Windows VR, Looking Glass |
+| [VRM Display](https://akarimichi.github.io/vrm-display-releases/) | Windows |
 
 ##  Others
 
-* [Vtabi](https://app.famitsu.com/gametitle/8356/)
-* [Vismuth](https://vismuth.net/)
-* [AI4Animation](https://github.com/t-takasaka/AI4Animation/tree/master/AI4Animation/Assets/Demo/ARKit)
-* [vstamp](https://yashinut.com/archives/vstamp_app.html)
-* [VRMLoaderUI](https://github.com/m2wasabi/VRMLoaderUI)
-* [TRACKING WORLD](http://deatrathias.net/TW/)
+| Application | Platform |
+|-------------|----------|
+| [Vtabi](https://app.famitsu.com/gametitle/8356/) | iOS, Android |
+| [Vismuth](https://vismuth.net/) | Android, iOS |
+| [AI4Animation](https://github.com/t-takasaka/AI4Animation/tree/master/AI4Animation/Assets/Demo/ARKit) | Unity library |
+| [vstamp](https://yashinut.com/archives/vstamp_app.html) | iOS, Android |
+| [VRMLoaderUI](https://github.com/m2wasabi/VRMLoaderUI) | Unity library |
+| [TRACKING WORLD](http://deatrathias.net/TW/) | Windows VR |

--- a/content/ja/docs/vrm/vrm_applications.md
+++ b/content/ja/docs/vrm/vrm_applications.md
@@ -14,72 +14,86 @@ weight: 4
 
 ##  プラグイン
 
-* [VRM_IMPORTER](https://github.com/saturday06/VRM_IMPORTER_for_Blender2_8) (Blenderアドオン)
-* [VRM4U](https://github.com/ruyo/VRM4U)
-* [glTF-Maya-Exporter](https://github.com/kashikacojp/glTF-Maya-Exporter)
-* [VRM Converter for VRChat](https://pokemori.booth.pm/items/1025226) (Unityエディタ拡張)
+| アプリケーション | プラットフォーム |
+|------------------|------------------|
+| [VRM_IMPORTER](https://github.com/saturday06/VRM_IMPORTER_for_Blender2_8) | Blenderアドオン |
+| [VRM4U](https://github.com/ruyo/VRM4U) | UnrealEngineプラグイン |
+| [glTF-Maya-Exporter](https://github.com/kashikacojp/glTF-Maya-Exporter) | Mayaスクリプト |
+| [VRM Converter for VRChat](https://pokemori.booth.pm/items/1025226) | Unityエディタ拡張 |
 
 ##  キャラメイクツール
 
-* [Vカツ](http://vkatsu.jp/)
-* [VRoid](https://vroid.com/)
-* [セシル変身アプリ](https://fantia.jp/fanclubs/10552)
+| アプリケーション | プラットフォーム |
+|------------------|------------------|
+| [Vカツ](http://vkatsu.jp/) | Windows, iOS, Android |
+| [VRoid](https://vroid.com/) | Windows, macOS |
+| [セシル変身アプリ](https://fantia.jp/fanclubs/10552) | Windows, macOS |
 
 ##  配信ツール
 
-* [バーチャルキャスト](https://virtualcast.jp/)
-* [カスタムキャスト](https://customcast.jp/)
-* [VDRAW](https://sites.google.com/view/vdraw/)
-* [REALITY](https://le.wrightflyer.net/reality/)
-* [SHOWROOM V](https://campaign.showroom-live.com/showroom-v/)
-* [Hitogata](https://sites.google.com/site/vhitogata/)
-* [3tene](https://3tene.com/)
-* [パペ文字](https://www.puppemoji.com/)
-* [Wakaru](https://store.steampowered.com/app/870820/Wakaru_ver_beta/)
-* [バーチャルモーションキャプチャー](https://github.com/sh-akira/VirtualMotionCapture)
-* [FaceVTuber](https://facevtuber.com/)
-* [メイアライブ（オーダーメイド版）](https://materializer.co/lab/mayalive)
-* [WeVTuber](https://wevtubers.appspot.com/)
-* [LiveAvatar](https://github.com/m2wasabi/LiveAvatar)
-* [[VR撮影アプリ] Clarie](https://biscrat.booth.pm/items/1193414)
-* [Luppet](https://luppet.appspot.com/)
-* [vear](https://apps.apple.com/jp/app/vear/id1490697369)
-* [CharWebCam](https://github.com/xelloss120/CharWebCam)
-* [VMagicMirror](https://malaybaku.github.io/VMagicMirror/)
+| アプリケーション | プラットフォーム |
+|------------------|------------------|
+| [バーチャルキャスト](https://virtualcast.jp/) | Windows VR |
+| [カスタムキャスト](https://customcast.jp/) | iOS, Android |
+| [VDRAW](https://sites.google.com/view/vdraw/) | Windows |
+| [REALITY](https://le.wrightflyer.net/reality/) | iOS, Android |
+| [SHOWROOM V](https://campaign.showroom-live.com/showroom-v/) | iOS |
+| [Hitogata](https://sites.google.com/site/vhitogata/) | Windows |
+| [3tene](https://3tene.com/) | Windows, macOS |
+| [パペ文字](https://www.puppemoji.com/) | iOS |
+| [Wakaru](https://store.steampowered.com/app/870820/Wakaru_ver_beta/) | Windows |
+| [バーチャルモーションキャプチャー](https://github.com/sh-akira/VirtualMotionCapture) | Windows VR |
+| [FaceVTuber](https://facevtuber.com/) | Google Chrome |
+| [メイアライブ（オーダーメイド版）](https://materializer.co/lab/mayalive) | Windows, macOS |
+| [WeVTuber](https://wevtubers.appspot.com/) | Windows Google Chrome, Safari |
+| [LiveAvatar](https://github.com/m2wasabi/LiveAvatar) | HTC VIVE |
+| [[VR撮影アプリ] Clarie](https://biscrat.booth.pm/items/1193414) | Windows VR |
+| [Luppet](https://luppet.appspot.com/) | Windows + Leap Motion |
+| [vear](https://apps.apple.com/jp/app/vear/id1490697369) | iOS |
+| [CharWebCam](https://github.com/xelloss120/CharWebCam) | Windows |
+| [VMagicMirror](https://malaybaku.github.io/VMagicMirror/) | Windows |
 
 ##  メタバース
 
-* [cluster](https://cluster.mu/)
-* [Vワールド](https://naby.booth.pm/items/990663)
+| アプリケーション | プラットフォーム |
+|------------------|------------------|
+| [cluster](https://cluster.mu/) | PCVR, Windows, macOS, iOS, Android |
+| [Vワールド](https://naby.booth.pm/items/990663) | Windows |
 
 ##  ゲームなど
 
-* [SEIYA](https://wandv.jp/seiya/)
-* [BONFIRE~焚き火~](https://orenodinner.booth.pm/items/952450)
-* [つんつんVR](https://store.steampowered.com/app/867090/VR__TSUNTSUN_VR/)
-* [コロコロシステム](https://www.mediaplex.co.jp/korokoro/)
-* [パイロットクロス](https://n-mattun.booth.pm/)
+| アプリケーション | プラットフォーム |
+|------------------|------------------|
+| [SEIYA](https://wandv.jp/seiya/) | Windows VR |
+| [BONFIRE~焚き火~](https://orenodinner.booth.pm/items/952450) | Oculus Go |
+| [つんつんVR](https://store.steampowered.com/app/867090/VR__TSUNTSUN_VR/) | Windows VR |
+| [コロコロシステム](https://www.mediaplex.co.jp/korokoro/) | Oculus Rift |
+| [パイロットクロス](https://n-mattun.booth.pm/) | Windows VR |
 
 ##  ビューア
 
-* [Babylon VRM Viewer](https://github.com/virtual-cast/babylon-vrm-loader/)
-* [Three-VRM](https://github.com/pixiv/three-vrm/)
-* [VPocket (Android / iOS)](https://play.google.com/store/apps/details?id=com.BooApps.VPocket)
-* [VRMビュアー](https://www43.atwiki.jp/beamman/)
-* [VRM Viewer](https://vrm-viewer.yukimochi.io/)
-* [VRMQuickLook](https://github.com/magicien/VRMQuickLook)
-* [VRM Live Viewer](http://fantom1x.blog130.fc2.com/blog-entry-309.html)
-* [UniWinApi Example project](https://github.com/kirurobo/UniWinApi)
-* [VRMお人形遊び](https://120byte.booth.pm/items/1099618)
-* [KinectV2VRM](https://github.com/m2wasabi/KinectV2VRM)
-* [MocuMocuVRM](http://www.vrai.jp/vr_mocuvrm.html)
-* [VRM Display](https://akarimichi.github.io/vrm-display-releases/)
+| アプリケーション | プラットフォーム |
+|------------------|------------------|
+| [Babylon VRM Viewer](https://github.com/virtual-cast/babylon-vrm-loader/) | Babylon.js拡張 |
+| [Three-VRM](https://github.com/pixiv/three-vrm/) | three.js拡張 |
+| [VPocket](https://play.google.com/store/apps/details?id=com.BooApps.VPocket) | Android, iOS |
+| [VRMビュアー](https://www43.atwiki.jp/beamman/) | Windows |
+| [VRM Viewer](https://vrm-viewer.yukimochi.io/) | Webブラウザ |
+| [VRMQuickLook](https://github.com/magicien/VRMQuickLook) | macOS |
+| [VRM Live Viewer](http://fantom1x.blog130.fc2.com/blog-entry-309.html) | Windows |
+| [UniWinApi Example project](https://github.com/kirurobo/UniWinApi) | Unityライブラリ |
+| [VRMお人形遊び](https://120byte.booth.pm/items/1099618) | Windows VR |
+| [KinectV2VRM](https://github.com/m2wasabi/KinectV2VRM) | Unityライブラリ |
+| [MocuMocuVRM](http://www.vrai.jp/vr_mocuvrm.html) | Windows VR, Looking Glass |
+| [VRM Display](https://akarimichi.github.io/vrm-display-releases/) | Windows |
 
 ##  その他のVRM対応アプリ
 
-* [Vタビ](https://app.famitsu.com/gametitle/8356/)
-* [Vismuth](https://vismuth.net/)
-* [AI4Animation](https://github.com/t-takasaka/AI4Animation/tree/master/AI4Animation/Assets/Demo/ARKit)
-* [Vスタンプ](https://yashinut.com/archives/vstamp_app.html)
-* [VRMLoaderUI](https://github.com/m2wasabi/VRMLoaderUI)
-* [TRACKING WORLD](http://deatrathias.net/TW/)
+| アプリケーション | プラットフォーム |
+|------------------|------------------|
+| [Vタビ](https://app.famitsu.com/gametitle/8356/) | iOS, Android |
+| [Vismuth](https://vismuth.net/) | Android, iOS |
+| [AI4Animation](https://github.com/t-takasaka/AI4Animation/tree/master/AI4Animation/Assets/Demo/ARKit) | Unityライブラリ |
+| [Vスタンプ](https://yashinut.com/archives/vstamp_app.html) | iOS, Android |
+| [VRMLoaderUI](https://github.com/m2wasabi/VRMLoaderUI) | Unityライブラリ |
+| [TRACKING WORLD](http://deatrathias.net/TW/) | Windows VR |


### PR DESCRIPTION
It may not be desirable to put a lot of information about “What applications that support VRM?” page, but at the very least it is useful to visitors to the page to describe the platform it runs on.