### PR TITLE
BlendShape のスクリプトからの設定方法を v0.58.0 基準に修正

### DIFF
--- a/content/ja/docs/dev/univrm-0.xx/programming/univrm_use_blendshape.md
+++ b/content/ja/docs/dev/univrm-0.xx/programming/univrm_use_blendshape.md
@@ -49,8 +49,8 @@ VRMBlendShape `Blink_R`
 このとき両目を閉じたいモチベーションから、両方を有効にする意図で下記のように実行します。
 
 {{< highlight cs >}}
-proxy.ImmediatelySetValue(BlendShapePreset.Blink_L, 1.0f);
-proxy.ImmediatelySetValue(BlendShapePreset.Blink_R, 1.0f);
+proxy.ImmediatelySetValue(BlendShapeKey.CreateFromPreset(BlendShapePreset.Blink_L), 1.0f);
+proxy.ImmediatelySetValue(BlendShapeKey.CreateFromPreset(BlendShapePreset.Blink_R), 1.0f);
 {{< / highlight >}}
 
 すると、左目だけが開いてしまいます。
@@ -61,15 +61,15 @@ proxy.ImmediatelySetValue(BlendShapePreset.Blink_R, 1.0f);
 {{< highlight cs >}}
 proxy.SetValues(new Dictionary<BlendShapeKey, float>
 {
-    {new BlendShapeKey(BlendShapePreset.Blink_L), 1.0f},
-    {new BlendShapeKey(BlendShapePreset.Blink_R), 1.0f},
+    {BlendShapeKey.CreateFromPreset(BlendShapePreset.Blink_L), 1.0f},
+    {BlendShapeKey.CreateFromPreset(BlendShapePreset.Blink_R), 1.0f},
 });
 {{< / highlight >}}
 
 または
 
 {{< highlight cs >}}
-proxy.AccumerateValue(BlendShapePreset.Blink_L, 1.0f); // すぐに適用せずにたくわえる
-proxy.AccumerateValue(BlendShapePreset.Blink_R, 1.0f);
+proxy.AccumerateValue(BlendShapeKey.CreateFromPreset(BlendShapePreset.Blink_L), 1.0f); // すぐに適用せずにたくわえる
+proxy.AccumerateValue(BlendShapeKey.CreateFromPreset(BlendShapePreset.Blink_R), 1.0f);
 proxy.Apply(); // 蓄積した値をまとめて適用する
 {{< / highlight >}}

--- a/content/ja/docs/dev/univrm-0.xx/programming/univrm_use_blendshape.md
+++ b/content/ja/docs/dev/univrm-0.xx/programming/univrm_use_blendshape.md
@@ -17,6 +17,9 @@ UniVRM v0.58.0
 
 ## スクリプトから BlendShape weight を適用する
 
+`SetValues` 関数のみを使用します。
+そのフレームで必要な表情の weight 値をすべて集めてから `SetValues` を 1 回だけ呼んで設定します。
+
 {{< highlight cs >}}
 var proxy = GetComponent<VRMBlendShapeProxy>();
 
@@ -29,6 +32,8 @@ proxy.SetValues(new Dictionary<BlendShapeKey, float>
 {{< / highlight >}}
 
 ## 複数の BlendShape weight を適用する際の競合の問題について
+
+この節では、なぜ `SetValues` を使わなければならないのかという疑問に回答します。
 
 たとえば 2 つの VRMBlendShape `Blink_L` と `Blink_R` が
 
@@ -48,8 +53,10 @@ proxy.ImmediatelySetValue(BlendShapePreset.Blink_L, 1.0f);
 proxy.ImmediatelySetValue(BlendShapePreset.Blink_R, 1.0f);
 {{< / highlight >}}
 
-すると後から `ImmediateSetValue` した `Blink_R` が weight を上書きしてしまい、左目が開いてしまいます。
-したがって VRM の表情制御においては下記の 2 通りのどちらかで書くことが求められます。
+すると、左目だけが開いてしまいます。
+これは後から `ImmediateSetValue` した `Blink_R` が `Blink_L` と競合して weight を上書きしてしまうからです。
+したがって VRM の表情制御においては下記の 2 通りのどちらかの方法で書くことが求められます。
+これらの方法はこの競合の問題を解決して表情を設定することができます。
 
 {{< highlight cs >}}
 proxy.SetValues(new Dictionary<BlendShapeKey, float>

--- a/content/ja/docs/dev/univrm-0.xx/programming/univrm_use_blendshape.md
+++ b/content/ja/docs/dev/univrm-0.xx/programming/univrm_use_blendshape.md
@@ -5,49 +5,51 @@ date: 2018-04-16T16:30:00+09:00
 url: "/dev/univrm-0.xx/programming/univrm_use_blendshape/"
 weight: 3
 ---
+## 環境
+UniVRM v0.58.0
 
-## スクリプトからBlendShapeを適用する
+## 使用するメソッド
+
+* [推奨] `SetValues`
+* [非推奨] `ImmediatelySetValue`
+* [上級者向け] `AccumulateValue`
+* [上級者向け] `Apply`
+
+## スクリプトから BlendShape weight を適用する
 
 {{< highlight cs >}}
-var proxy=GetComponent<VRMBlendShapeProxy>();
+var proxy = GetComponent<VRMBlendShapeProxy>();
 
-// enumで呼び出し
-proxy.ImmediatelySetValue(BlendShapePreset.A, 1.0f); // 0から1で指定
-
-// stringで呼び出し
-proxy.ImmediatelySetValue("A", 1.0f);
+proxy.SetValues(new Dictionary<BlendShapeKey, float>
+{
+    {BlendShapeKey.CreateFromPreset(BlendShapePreset.A), 1f}, // [0, 1] の範囲で Weight を指定
+    {BlendShapeKey.CreateFromPreset(BlendShapePreset.Joy), 1f}, // システム定義の表情は enum で指定
+    {BlendShapeKey.CreateUnknown("USER_DEFINED_FACIAL"), 1f}, // ユーザ定義の表情は string で指定
+});
 {{< / highlight >}}
 
-## 複数のBlendShapeをまとめて適用する
+## 複数の BlendShape weight を適用する際の競合の問題について
 
-たとえば
+たとえば 2 つの VRMBlendShape `Blink_L` と `Blink_R` が
 
-Blink_Lが
+VRMBlendShape `Blink_L`
+* Mesh `A` の Blendshape `eye_close_L` の weight 値 `100`
+* Mesh `A` の Blendshape `eye_close_R` の weight 値 `1`
 
-* MeshAのeye_L=100
-* MeshAのeye_R=1
+VRMBlendShape `Blink_R`
+* Mesh `A` の Blendshape `eye_close_L` の weight 値 `1`
+* Mesh `A` の Blendshape `eye_close_R` の weight 値 `100`
 
-Blink_Rが
-
-* MeshAのeye_L=1
-* MeshAのeye_R=100
-
-で定義されている場合に両方を有効にする意図で下記のようにすると、後からセットしたものだけが適用されてしまいます。
+で定義されているとします。
+このとき両目を閉じたいモチベーションから、両方を有効にする意図で下記のように実行します。
 
 {{< highlight cs >}}
 proxy.ImmediatelySetValue(BlendShapePreset.Blink_L, 1.0f);
 proxy.ImmediatelySetValue(BlendShapePreset.Blink_R, 1.0f);
 {{< / highlight >}}
 
-この場合は、以下のようにできます。
-
-{{< highlight cs >}}
-proxy.AccumerateValue(BlendShapePreset.Blink_L, 1.0f); // すぐに適用せずにたくわえる
-proxy.AccumerateValue(BlendShapePreset.Blink_R, 1.0f);
-proxy.Apply(); // 蓄積した値をまとめて適用する
-{{< / highlight >}}
-
-または
+すると後から `ImmediateSetValue` した `Blink_R` が weight を上書きしてしまい、左目が開いてしまいます。
+したがって VRM の表情制御においては下記の 2 通りのどちらかで書くことが求められます。
 
 {{< highlight cs >}}
 proxy.SetValues(new Dictionary<BlendShapeKey, float>
@@ -55,4 +57,12 @@ proxy.SetValues(new Dictionary<BlendShapeKey, float>
     {new BlendShapeKey(BlendShapePreset.Blink_L), 1.0f},
     {new BlendShapeKey(BlendShapePreset.Blink_R), 1.0f},
 });
+{{< / highlight >}}
+
+または
+
+{{< highlight cs >}}
+proxy.AccumerateValue(BlendShapePreset.Blink_L, 1.0f); // すぐに適用せずにたくわえる
+proxy.AccumerateValue(BlendShapePreset.Blink_R, 1.0f);
+proxy.Apply(); // 蓄積した値をまとめて適用する
 {{< / highlight >}}


### PR DESCRIPTION
`VRMBlendShapeProxy` の使用方法を UniVRM v0.58.0 基準のものに修正。