### PR TITLE
Move “MakeAvatar” to Services using VRM internally category in vrm_applications page

### DIFF
--- a/content/en/docs/vrm/vrm_applications.md
+++ b/content/en/docs/vrm/vrm_applications.md
@@ -29,7 +29,6 @@ weight: 4
 |-------------|----------|
 | [VRoid Studio](https://vroid.com/en/studio/) | Windows, macOS |
 | [CecilHenShin](https://fantia.jp/fanclubs/10552) | Windows, macOS |
-| [MakeAvatar](https://gugenka.jp/digital/make_avatar.php) | iOS, Android |
 
 ##  Live streaming tool
 
@@ -128,3 +127,4 @@ weight: 4
 | [REALITY](https://reality.wrightflyer.net/) | iOS, Android |
 | [Puppemoji](https://www.puppemoji.com/) | iOS |
 | [Mayalive Order Made Version](https://materializer.co/lab/mayalive) | Windows, macOS |
+| [MakeAvatar](https://gugenka.jp/digital/make_avatar.php) | iOS, Android |

--- a/content/ja/docs/vrm/vrm_applications.md
+++ b/content/ja/docs/vrm/vrm_applications.md
@@ -29,7 +29,6 @@ weight: 4
 |------------------|------------------|
 | [VRoid Studio](https://vroid.com/studio/) | Windows, macOS |
 | [セシル変身アプリ](https://fantia.jp/fanclubs/10552) | Windows, macOS |
-| [MakeAvatar](https://gugenka.jp/digital/make_avatar.php) | iOS, Android |
 
 ##  配信ツール
 
@@ -128,3 +127,4 @@ weight: 4
 | [REALITY](https://reality.wrightflyer.net/) | iOS, Android |
 | [パペ文字](https://www.puppemoji.com/) | iOS |
 | [メイアライブオーダーメイド版](https://materializer.co/lab/mayalive) | Windows, macOS |
+| [MakeAvatar](https://gugenka.jp/digital/make_avatar.php) | iOS, Android |


### PR DESCRIPTION
MakeAvatar does not support VRM file export like Vkatsu, Custom Cast, and REALITY do not.