### PR TITLE
本番環境としてビルドするように変更しminifyを再度有効化

### DIFF
--- a/.github/workflows/hugo_build.yml
+++ b/.github/workflows/hugo_build.yml
@@ -25,7 +25,7 @@ jobs:
           # Download (if necessary) and use Hugo extended version. Example: true
           extended: true
       - name: Build Hugo
-        run: hugo -v
+        run: HUGO_ENV=production hugo -v --minify
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3
         with:


### PR DESCRIPTION
意図的な変更であれば申し訳ないのですが、サイトのビルドをTravisからGitHub Actionsに移行した際にビルド時に本番環境としてビルドされなくなった影響で `robots` metaタグに `noindex, nofollow` が設定されGoogleなどでインデックスされていない状態となっておりました。
また、Travisでビルドを実行していた際に有効化になっていたminifyも無効になっていたので再度有効化いたしました。
いくつかのページを確認しましたがminifyの再有効化の影響は特になさそうです。