### PR TITLE
Fix missing spaces in English text of the VRM public license

### DIFF
--- a/licenses/en/1.0/_index.md
+++ b/licenses/en/1.0/_index.md
@@ -10,16 +10,16 @@ By exercising the Licensed Rights (as defined below), You (as defined below) acc
   <li>“<b>Adapted Work Data</b>” means a VRM file subject to Copyright and Similar Rights that is derived from or based upon the Licensed Work Data and in which the Licensed Work Data is translated, altered, arranged, transformed, or otherwise modified in a manner requiring permission under the Copyright and Similar Rights held by the Licensor.</li></li>
   <li>“<b>Adapter’s License</b>” means the license You apply to Your Copyright and Similar Rights in Your contributions to Adapted Work Data in accordance with the terms and conditions of this Public License.</li>
   <li>“<b>Copyright and Similar Rights</b>” means copyright and/or similar rights closely related to copyright including, without limitation, performance, broadcast, sound recording, and sui generis database rights, without regard to how the rights are labeled or categorized. For purposes of this Public License, the rights specified in Sections 2(b)(1) and (2) are not Copyright and Similar Rights.</li>
-  <li>“<b>Effective Technological Measures</b>” means those measures that, in the absence of proper authority, may not be circumvented under laws fulfilling obligations under Article 11 ofthe WIPO Copyright Treaty adopted on December 20, 1996, and/or similar international agreements.</li>
+  <li>“<b>Effective Technological Measures</b>” means those measures that, in the absence of proper authority, may not be circumvented under laws fulfilling obligations under Article 11 of the WIPO Copyright Treaty adopted on December 20, 1996, and/or similar international agreements.</li>
   <li>“<b>Exceptions and Limitations</b>” means fair use, fair dealing, and/or any other exception or limitation to Copyright and Similar Rights that applies to Your use of the Licensed Work Data.</li>
   <li>“<b>Licensed Work Data</b>” means a 3D model data created using VRM (VRM file) that is the subject of the license under this Public License and is licensed for use under such license.</li>
   <li>“<b>Licensed Rights</b>” means the rights granted to You subject to the terms and conditions of this Public License, which are limited to all Copyright and Similar Rights that apply to Your useof the Licensed Work Data and that the Licensor has authority to license.</li>
-  <li>“<b>License Settings</b>” means the part of the Licensed Work Data that contains the Licensor’s designation of the subject and terms of the license under this Public License. The License Setting constitutes, together with this Public License, the terms and conditions of the license of the Licensed Work Data grantedto You.</li>
+  <li>“<b>License Settings</b>” means the part of the Licensed Work Data that contains the Licensor’s designation of the subject and terms of the license under this Public License. The License Setting constitutes, together with this Public License, the terms and conditions of the license of the Licensed Work Data granted to You.</li>
   <li>“<b>Licensor</b>” means the individual(s) or entity(ies) granting the Licensed Rights under this Public License.</li>
   <li>“<b>Non-commercial</b>” means not primarily intended for, and not primarily directed to, commercial gain or monetary compensation. For purposes of this Public License, an exchange of Licensed Work Data for other material covered by Copyright and Similar Rights is non-commercial if no monetary compensation is paid in connection with the exchange.</li>
-  <li>“<b>Redistribution</b>” means to provide a VRM file to the public by any means or process that requires permission under the Licensed Rights, such as reproduction, public display, public performance, distribution, dissemination, communication, or importation, and to make a VRM file available to the public including in ways that members of the public may access the material from a place and at a time individually chosen by them. For the avoidance of doubt, reproduction or otherwise using the Licensed Work Data to the extent necessary for ModelUse or Avatar Use (if applicable) of the Licensed Work Data does not constitute Redistribution.</li>
+  <li>“<b>Redistribution</b>” means to provide a VRM file to the public by any means or process that requires permission under the Licensed Rights, such as reproduction, public display, public performance, distribution, dissemination, communication, or importation, and to make a VRM file available to the public including in ways that members of the public may access the material from a place and at a time individually chosen by them. For the avoidance of doubt, reproduction or otherwise using the Licensed Work Data to the extent necessary for Model Use or Avatar Use (if applicable) of the Licensed Work Data does not constitute Redistribution.</li>
   <li>“<b>You</b>” means the individual or entity exercising the Licensed Rights under this Public License. “<b>Your</b>” has a corresponding meaning.</li>
-  <li>“<b>Manipulation</b>” means adding motion (including adding sound)to the 3D avatar pertaining to a specific VRM file by executing the VRM file on an application.</li>
+  <li>“<b>Manipulation</b>” means adding motion (including adding sound) to the 3D avatar pertaining to a specific VRM file by executing the VRM file on an application.</li>
   <li>“<b>Model Use</b>” means publicly transmitting, making available for transmission, or showing of a series of images obtained by Manipulating the 3D avatar pertaining to a specific VRM file for the purpose of having a third party view it, excluding Avatar Use.</li>
   <li>“<b>Personify</b>” means to Manipulate the 3D avatar of a specific VRM file by expressly or implicitly stating that such manipulation expresses words and actions reflecting the intentions of a real or virtual personality.
   <li>“<b>Avatar Use</b>” means publicly transmitting, making available fortransmission, or showing of a series of images obtained by Personifying the 3D avatar pertaining to a specific VRM file for the purpose of having a third party view it.</li>
@@ -42,13 +42,13 @@ By exercising the Licensed Rights (as defined below), You (as defined below) acc
     <li>If the Licensor so specifies in the License Settings, the license in Section 2(a)(1) is granted only if You make the use described in the said Section for Non-commercial purposes.</li>
     <li>If the Licensor so specifies in the License Settings, the license in Section 2(a)(1) is granted only to You for Your personal use as set forth in the said Section.</li>
     <li>If the Licensor establishes its own terms in the License Settings other than those set forth in this Public License, the license under Section 2(a)(1) is granted only if You comply with such terms.</li>
-    <li><u>Exceptions and Limitations</u>. For the avoidance of doubt, where Exceptions and Limitations apply to Your use of theLicensed Work Data, this Public License does not apply, and You do not need to comply with its terms and conditions.</li>
+    <li><u>Exceptions and Limitations</u>. For the avoidance of doubt, where Exceptions and Limitations apply to Your use of the Licensed Work Data, this Public License does not apply, and You do not need to comply with its terms and conditions.</li>
     <li><u>Term</u>. The term of this Public License is specified in Section 6(a).</li>
-    <li><u>Media and formats; technical modifications allowed</u>. The Licensor authorizes You to exercise the Licensed Rights inall media and formats whether now known or hereafter created, and to make technical modifications necessary todo so. The Licensor waives and/or agrees not to assert any right or authority to forbid You from making technical modifications necessary to exercise the Licensed Rights, including technical modifications necessary to circumventEffective Technological Measures. For purposes of this Public License, simply making modifications authorized bythis Section 2(a)(7) shall not be deemed production of Adapted Work Data.</li>
+    <li><u>Media and formats; technical modifications allowed</u>. The Licensor authorizes You to exercise the Licensed Rights in all media and formats whether now known or hereafter created, and to make technical modifications necessary to do so. The Licensor waives and/or agrees not to assert any right or authority to forbid You from making technical modifications necessary to exercise the Licensed Rights, including technical modifications necessary to circumvent Effective Technological Measures. For purposes of this Public License, simply making modifications authorized by this Section 2(a)(7) shall not be deemed production of Adapted Work Data.</li>
     <li><u>Downstream recipients</u>.</li>
     <ol type="A" style="list-style-type: upper-latin">
-      <li><u>Offer from the Licensor - Licensed Work Data</u>. Everyrecipient of the Licensed Work Data automatically receives an offer from the Licensor to exercise the Licensed Rights under the terms and conditions of this Public License.</li>
-      <li><u>Additional offer from the Licensor - Adapted Work Data</u>. In cases where the Licensor grants the right todo the act listed in Section 2(a)(1)(D) as a Licensed Right in the License Settings, every recipient of Adapted Work Data from You automatically receivesan offer from the Licensor to exercise the Licensed Rights in the Adapted Work Data under the conditions of the Adapter’s License You apply.</li>
+      <li><u>Offer from the Licensor - Licensed Work Data</u>. Every recipient of the Licensed Work Data automatically receives an offer from the Licensor to exercise the Licensed Rights under the terms and conditions of this Public License.</li>
+      <li><u>Additional offer from the Licensor - Adapted Work Data</u>. In cases where the Licensor grants the right to do the act listed in Section 2(a)(1)(D) as a Licensed Right in the License Settings, every recipient of Adapted Work Data from You automatically receives an offer from the Licensor to exercise the Licensed Rights in the Adapted Work Data under the conditions of the Adapter’s License You apply.</li>
       <li><u>No downstream restrictions</u>. You may not offer or impose any additional or different terms or conditions on, or apply any Effective Technological Measures to, the Licensed Work Data if doing so restricts exercise of the Licensed Rights by any recipient of the Licensed Work Data.</li>
     </ol>
     <li><u>No endorsement</u>. Nothing in this Public License constitutes or may be construed as permission to assert or imply that You are, or that Your use of the Licensed Work Data is, connected with, or sponsored, endorsed, or granted official status by, the Licensor or others designated to receive attribution as provided in Section 3(a)(1)(A)(i) (as applicable).</li>
@@ -57,7 +57,7 @@ By exercising the Licensed Rights (as defined below), You (as defined below) acc
   <ol type="1">
     <li>Moral rights, such as the right of integrity, are not licensed under this Public License, nor are publicity, privacy, and/or other similar personality rights; however, to the extent possible, the Licensor waives and/or agrees not to assert any such rights held by the Licensor to the limited extent necessary to allow You to exercise the Licensed Rights, but not otherwise.</li>
     <li>Patent and trademark rights are not licensed under this Public License.</li>
-    <li>To the extent possible, the Licensor waives any right to collect royalties from You for the exercise of the Licensed Rights, whether directly or through a collecting society under any voluntary or waivable statutory or compulsory licensing scheme. In all other cases the Licensor expresslyreserves any right to collect such royalties.</li>
+    <li>To the extent possible, the Licensor waives any right to collect royalties from You for the exercise of the Licensed Rights, whether directly or through a collecting society under any voluntary or waivable statutory or compulsory licensing scheme. In all other cases the Licensor expressly reserves any right to collect such royalties.</li>
   </ol>
 </ol>
 
@@ -72,20 +72,20 @@ Your exercise of the Licensed Rights is expressly made subject to the following 
     <ol type="A" style="list-style-type: upper-latin">
       <li>retain the following if it is supplied by the Licensor with the Licensed Work Data:</li>
       <ol type="i">
-        <li>identification of the creator(s) of the Licensed Work Data and any others designated by the Licensor to receive attribution, in any reasonable manner requested by the Licensor(including by pseudonym, if designated);</li>
+        <li>identification of the creator(s) of the Licensed Work Data and any others designated by the Licensor to receive attribution, in any reasonable manner requested by the Licensor (including by pseudonym, if designated);</li>
         <li>a copyright notice;</li>
         <li>a notice that refers to this Public License;</li>
         <li>a notice that refers to the disclaimer of warranties; and</li>
         <li>a URI or hyperlink to the Licensed Work Data to the extent reasonably practicable;</li>
       </ol>
-      <li>indicate if You modified the Licensed Work Data andretain an indication of any previous modifications; and</li>
+      <li>indicate if You modified the Licensed Work Data and retain an indication of any previous modifications; and</li>
       <li>indicate the Licensed Work Data is licensed under this Public License, and include the text of, or the URI or hyperlink to, this Public License.</li>
     </ol>
     <li>If requested by the Licensor, You must remove any of the information required by Section 3(a)(1)(A) to the extent reasonably practicable.</li>
   </ol>
   <li><b>Conditions for Redistribution of Adaptation</b>.</li>
   <ol type="1">
-    <li>If You Redistribute Adapted Work Data that You created, the Adapter’s License that You grant shall not prevent therecipients of the Adapted Work Data from applying this Public License to the Licensed Work Data.</li>
+    <li>If You Redistribute Adapted Work Data that You created, the Adapter’s License that You grant shall not prevent the recipients of the Adapted Work Data from applying this Public License to the Licensed Work Data.</li>
     <li>The subject acts and terms of the Adapter’s License granted by You shall be the same as or more restrictive than those in this Public License.</li>
     <li>If You Redistribute the Adapted Work Data that You created, You shall include the terms of the Adapter’s License that applies to You in the License Settings of the Adapted Work Data.</li>
   </ol>
@@ -125,8 +125,8 @@ Your exercise of the Licensed Rights is expressly made subject to the following 
 ## Section 4. Disclaimer of Warranties and Limitation of Liability.
 
 <ol type="a">
-  <li><b>Unless otherwise separately undertaken by the Licensor,to the extent possible, the Licensor offers the Licensed Work Data as-is and as-available, and makes no representations or warranties of any kind concerning theLicensed Work Data, whether express, implied, statutory, or other. This includes, without limitation, warranties of title, merchantability, fitness for a particular purpose, non-infringement, absence of latent or other defects, accuracy, or the presence or absence oferrors, whether or not known or discoverable. Where disclaimers of warranties are not allowed in full or in part, this disclaimer may not apply to You.</b></li>
-  <li><b>To the extent possible, in no event will the Licensor be liable to You on any legal theory (including, without limitation, negligence) or otherwise for any direct, special, indirect, incidental, consequential, punitive, exemplary, or other losses, costs, expenses, or damagesarising out of this Public License or use of the Licensed Work Data, even if the Licensor has been advised of the possibility of such losses, costs, expenses, or damages. Where a limitation of liability is not allowed in full or in part, this limitation may not apply to You.</b></li>
+  <li><b>Unless otherwise separately undertaken by the Licensor, to the extent possible, the Licensor offers the Licensed Work Data as-is and as-available, and makes no representations or warranties of any kind concerning the Licensed Work Data, whether express, implied, statutory, or other. This includes, without limitation, warranties of title, merchantability, fitness for a particular purpose, non-infringement, absence of latent or other defects, accuracy, or the presence or absence oferrors, whether or not known or discoverable. Where disclaimers of warranties are not allowed in full or in part, this disclaimer may not apply to You.</b></li>
+  <li><b>To the extent possible, in no event will the Licensor be liable to You on any legal theory (including, without limitation, negligence) or otherwise for any direct, special, indirect, incidental, consequential, punitive, exemplary, or other losses, costs, expenses, or damages arising out of this Public License or use of the Licensed Work Data, even if the Licensor has been advised of the possibility of such losses, costs, expenses, or damages. Where a limitation of liability is not allowed in full or in part, this limitation may not apply to You.</b></li>
   <li>The disclaimer of warranties and limitation of liability provided above shall be interpreted in a manner that, to the extent possible, most closely approximates an absolute disclaimer and waiver of all liability.</li>
 </ol>
 
@@ -134,12 +134,12 @@ Your exercise of the Licensed Rights is expressly made subject to the following 
 
 <ol type="a">
   <li>This Public License applies for the term of the Copyright and Similar Rights licensed here. However, if You fail to comply with this Public License, then Your rights under this Public License terminate automatically.</li>
-  <li>Where Your right to use the Licensed Work Data has terminatedunderSection 5(a), it reinstates:</li>
+  <li>Where Your right to use the Licensed Work Data has terminated under Section 5(a), it reinstates:</li>
   <ol type="1">
     <li>automatically as of the date the violation is cured, provided it is cured within 30 days of Your discovery of the violation; or</li>
     <li>upon express reinstatement by the Licensor.</li>
   </ol>
-  <p>For the avoidance of doubt, this Section 5(b) does not affect anyright the Licensor may have to seek remedies for Your violationsof this Public License.</p>
+  <p>For the avoidance of doubt, this Section 5(b) does not affect any right the Licensor may have to seek remedies for Your violations of this Public License.</p>
   <li>For the avoidance of doubt, the Licensor may also offer the Licensed Work Data under separate terms or conditions or stop distributing the Licensed Work Data at any time; however, doing so will not terminate this Public License.</li>
   <li>Sections 1, 4, 5, 6, and 7 survive termination of this Public License.</li>
 </ol>
@@ -156,8 +156,8 @@ Your exercise of the Licensed Rights is expressly made subject to the following 
 <ol type="a">
   <li>For the avoidance of doubt, this Public License does not, and shall not be interpreted to, reduce, limit, restrict, or impose conditions on any use of the Licensed Work Data that could lawfully be made without permission under this Public License.</li>
   <li>To the extent possible, if any provision of this Public License is deemed unenforceable, it shall be automatically reformed to the minimum extent necessary to make it enforceable. If the provision cannot be reformed, it shall be severed from this Public License without affecting the enforceability of the remaining terms and conditions.</li>
-  <li>No term or condition of this Public License will be waived and nofailure to comply consented to unless expressly agreed to by the Licensor.</li>
-  <li>Nothing in this Public License constitutes or may be interpreted as a limitation upon, or waiver of, any privileges and immunitiesthat apply to the Licensor or You, including from the legal processes of any jurisdiction or authority.</li>
+  <li>No term or condition of this Public License will be waived and no failure to comply consented to unless expressly agreed to by the Licensor.</li>
+  <li>Nothing in this Public License constitutes or may be interpreted as a limitation upon, or waiver of, any privileges and immunities that apply to the Licensor or You, including from the legal processes of any jurisdiction or authority.</li>
 </ol>
 
 <p class="revised-date">


### PR DESCRIPTION
The English text of the VRM public license contained some small mistakes. Throughout the text spaces were missing. This PR just adds spaces where they are supposed to be and does not change the contents of the license.