### PR TITLE
Update URL for "VRM Add-on for Blender"

### DIFF
--- a/docs/locale/en/LC_MESSAGES/vrm/vrm_applications.po
+++ b/docs/locale/en/LC_MESSAGES/vrm/vrm_applications.po
@@ -68,10 +68,10 @@ msgstr "Unity editor extension, Unity library"
 #: ../../vrm/vrm_applications.md
 msgid ""
 "[VRM Add-on for "
-"Blender](https://github.com/saturday06/VRM_Addon_for_Blender)"
+"Blender](https://vrm-addon-for-blender.info/ja)"
 msgstr ""
 "[VRM Add-on for "
-"Blender](https://github.com/saturday06/VRM_Addon_for_Blender)"
+"Blender](https://vrm-addon-for-blender.info/en)"
 
 #: ../../vrm/vrm_applications.md
 msgid "Blenderアドオン"

--- a/docs/vrm/vrm_applications.md
+++ b/docs/vrm/vrm_applications.md
@@ -20,7 +20,7 @@ weight: 4
 | アプリケーション | プラットフォーム |
 |------------------|------------------|
 | [UniVRM](https://github.com/vrm-c/UniVRM) | Unityエディタ拡張, Unityライブラリ |
-| [VRM Add-on for Blender](https://github.com/saturday06/VRM_Addon_for_Blender) | Blenderアドオン |
+| [VRM Add-on for Blender](https://vrm-addon-for-blender.info/ja) | Blenderアドオン |
 | [VRM4U](https://github.com/ruyo/VRM4U) | UnrealEngineプラグイン |
 | [godot-vrm](https://github.com/V-Sekai/godot-vrm) | Godotアドオン |
 | [glTF-Maya-Exporter](https://github.com/kashikacojp/glTF-Maya-Exporter) | Mayaスクリプト |


### PR DESCRIPTION
VRM Add-on for Blenderのメンテナです。GitHubのページへのリンクを記載いただいていましたが、新たにGitHubとは別に公式サイトを作りました。そのため、URLの変更をお願いします。