### PR TITLE
Update exokit website in vrm applications page

### DIFF
--- a/docs/vrm/vrm_applications.md
+++ b/docs/vrm/vrm_applications.md
@@ -120,7 +120,7 @@ weight: 4
 |`1.0`| [バーチャルキャスト](https://virtualcast.jp/) | [Windows VR](https://store.steampowered.com/app/947890/VirtualCast/), [Oculus Quest](https://www.oculus.com/experiences/quest/4174249979259348/) |
 |     | [cluster](https://cluster.mu/) | PCVR, Windows, macOS, iOS, Android |
 |     | [Clarie](https://biscrat.booth.pm/items/1193414) | Windows VR |
-|     | [Exokit](https://exokit.org/) | Windows, macOS, Linux, VR |
+|     | [Exokit](https://github.com/exokitxr/avatars) | Windows, macOS, Linux, VR |
 |     | [TECO](https://teco-vr.com/) | Windows, macOS, Oculus |
 |     | [コラボル](https://brother-pv.booth.pm/items/2016717) | Windows VR |
 |     | [Webaverse](https://webaverse.com/) | Web browser |


### PR DESCRIPTION
The old domain expired and is redirecting to a NSFW website

This PR changes to the github repo where vrm webxr demo + source code is hosted.