### PR TITLE
add dverso.io to users

### DIFF
--- a/src/data/users.ts
+++ b/src/data/users.ts
@@ -2308,4 +2308,19 @@ export const users: User[] = [
       "description": "Android, iOS"
     }
   },
+  {
+    "tag": "Metaverse",
+    "ja": {
+      "title": "dverso.io",
+      "url": "https://dverso.io",
+      "description": "Windows, macOS, iOS, Android",
+      "preview": "https://assets.dverso.io/logo.png"
+    },
+    "en": {
+      "title": "dverso.io",
+      "url": "https://dverso.io",
+      "description": "Windows, macOS, iOS, Android",
+      "preview": "https://assets.dverso.io/logo.png"
+    }
+  },
 ];


### PR DESCRIPTION
Adding dverso.io platform, a web based metaverse that enable users to create maps and use vrm freely also supporting face tracking tech