### PR TITLE
ShowCaseのclusterの情報をVRM1.0サポートに伴って更新する

### DIFF
--- a/src/data/users.ts
+++ b/src/data/users.ts
@@ -799,8 +799,8 @@ export const users: User[] = [
     "updated": new Date("2024-07-01"),
   },
   {
-    "flags": F.Metaverse,
-    "platforms": P.WindowsVR | P.Windows | P.macOS | P.iOS | P.Android,
+    "flags": F.Metaverse | F.Vrm10,
+    "platforms": P.WindowsVR | P.Windows | P.macOS | P.iOS | P.Android | P.MetaQuest,
     "ja": {
       "title": "cluster",
       "url": "https://cluster.mu/",

--- a/src/data/users.ts
+++ b/src/data/users.ts
@@ -804,7 +804,7 @@ export const users: User[] = [
     "ja": {
       "title": "cluster",
       "url": "https://cluster.mu/",
-      "preview": "https://cluster.mu/ogp.png"
+      "preview": "https://file-storage.cluster.mu/images/vrm/cluster_1280_720.png"
     },
     "updated": new Date("2023-01-03"),
   },


### PR DESCRIPTION
恐れ入ります。クラスター株式会社のすぎしーと申します。

この度clusterにて正式に[VRM1.0のアバターのサポート](https://help.cluster.mu/hc/ja/articles/37070598010009-cluster-v2-139-2024-09-02)を開始しましたため、ShowCaseの項目の更新を依頼させてください。

また、併せてpreviewやplatformsも更新させていただければと思います。

よろしくお願いします。