### PR TITLE
Add VTubeMe (selfie → VRM avatar creation tool)

### DIFF
--- a/src/data/users.ts
+++ b/src/data/users.ts
@@ -234,6 +234,21 @@ export const users: User[] = [
   },
   {
     "flags": F.CharacterCreation,
+    "ja": {
+      "title": "VTubeMe",
+      "url": "https://vtubeme.com/",
+      "description": "セルフィー1枚から写実的な3D VRMアバターを数分で作成。VSeeFace・Warudo・3teneなどに対応。",
+      "preview": "https://vtubeme.com/opengraph-image"
+    },
+    "en": {
+      "title": "VTubeMe",
+      "url": "https://vtubeme.com/",
+      "description": "Create a photorealistic 3D VRM avatar from a single selfie in minutes. Works with VSeeFace, Warudo and 3tene.",
+      "preview": "https://vtubeme.com/opengraph-image"
+    }
+  },
+  {
+    "flags": F.CharacterCreation,
     "platforms": P.WebBrowser,
     "ja": {
       "title": "Character Studio",


### PR DESCRIPTION
Adds **VTubeMe** to the character-creation tools in `src/data/users.ts`, alongside VRoid Studio / VRoid Mobile.

VTubeMe is a browser-based tool that turns a single selfie into a photorealistic 3D **VRM** avatar in minutes (no manual modeling), for use in VSeeFace, Warudo, 3tene and other VRM apps. It felt like a natural fit for the `CharacterCreation` category.

- Site: https://vtubeme.com/
- Output: standard `.vrm` (+ `.glb`)

Thanks for maintaining vrm.dev! Happy to adjust the wording/preview if needed.